### PR TITLE
Removing node name declaration in launch file

### DIFF
--- a/zuuu_hal/launch/hal.launch.py
+++ b/zuuu_hal/launch/hal.launch.py
@@ -51,7 +51,7 @@ def generate_launch_description():
         Node(
             package="zuuu_hal",
             executable="hal",
-            name="zuuu_hal",
+            # name="zuuu_hal_du_launch", -> Not declaring the name here as it overrides the node names and creates conflicts
             parameters=[
                 config,
                 {"fake": fake_mode, "gazebo": gazebo_mode, "use_sim_time": use_sim_time},


### PR DESCRIPTION
The name declared in the launch file was overriding the names of both nodes declared in the executable:
- zuuu_hal
- mobile_base_goto_action_server

Removing the name declaration in the launch file fixes the issue.

Ran all reachy2-sdk online tests with this version and got 1 error (0.020092 > 0.02):
![image](https://github.com/user-attachments/assets/b2fc9a61-0384-4f33-82e8-fd76047f6792)

I believe we should an some lenience on these hard limits, this looks like a floating point precision error.

I then ran the faulty test 10 times in a row and got 10 successes.