### PR TITLE
Remove debug log

### DIFF
--- a/zuuu_hal/zuuu_hal/zuuu_hal.py
+++ b/zuuu_hal/zuuu_hal/zuuu_hal.py
@@ -1118,7 +1118,6 @@ class ZuuuHAL(Node):
             self.x_vel_goal = self.cmd_vel.linear.x
             self.y_vel_goal = self.cmd_vel.linear.y
             self.theta_vel_goal = self.cmd_vel.angular.z
-            self.get_logger().error(f"self.x_vel_goal : {self.x_vel_goal}")
         else:
             self.x_vel_goal, self.y_vel_goal, self.theta_vel_goal = 0.0, 0.0, 0.0
 


### PR DESCRIPTION
A debug log is spamming in the core, coming from zuuu_hal : 
<img width="1049" height="676" alt="image" src="https://github.com/user-attachments/assets/f4bd0829-a996-46ab-8e02-00a9ba4c37b5" />

This PR removes it